### PR TITLE
Add Streamlit-based unlimited Wordle clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# wordle
+# Wordle senza limiti
+
+Web app tipo Wordle sviluppata con [Streamlit](https://streamlit.io) che supporta parole di lunghezza arbitraria. La parola segreta è scelta da dizionari caricati manualmente e cambia ogni giorno nella modalità Daily basata sul fuso orario Europe/Rome.
+
+## Requisiti
+
+- Python 3.10 o superiore
+- Dipendenze elencate in `requirements.txt`
+
+Installa le dipendenze ed avvia l'applicazione con:
+
+```bash
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+## Dizionari
+
+La logica si basa su due file di testo posizionati nella cartella `data/`:
+
+- `data/answers.txt`: elenco delle possibili parole segrete, una per riga, senza limitazioni di lunghezza.
+- `data/allowed.txt`: parole accettate come tentativi. Può includere anche le soluzioni.
+
+Se i file non esistono vengono creati automaticamente con un esempio minimo e l'app mostra un avviso. Sostituiscili con i tuoi elenchi (una parola per riga, niente spazi iniziali/finali). Non vengono normalizzati accenti o maiuscole/minuscole: le parole sono confrontate così come scritte nei file.
+
+## Modalità di gioco
+
+- **Daily**: tutti i giocatori ricevono la stessa parola del giorno. L'indice è calcolato sulla data locale Europe/Rome e cambia a mezzanotte.
+- **Free play**: genera una nuova parola casuale ogni volta che premi "Nuova partita".
+
+Nel pannello laterale puoi modificare il numero massimo di tentativi (default 6), attivare la modalità difficile (i tentativi successivi devono rispettare le lettere già confermate) e abilitare una palette ad alto contrasto per daltonici.
+
+## Interfaccia
+
+- Griglia dinamica che si adatta alla lunghezza della parola corrente.
+- Tastiera virtuale mostrata automaticamente quando l'alfabeto dei dizionari è compatto (≤40 simboli stampabili).
+- Campo di input senza limite di caratteri: la validazione assicura che ogni tentativo abbia la stessa lunghezza della soluzione ed esista nel dizionario consentito.
+- Pulsanti rapidi per inviare, cancellare o avviare una nuova partita e bottone di condivisione che copia negli appunti la griglia in formato emoji.
+
+## Test
+
+Esegui la suite automatica con:
+
+```bash
+pytest
+```
+
+I test coprono lo scoring delle parole, la gestione dei duplicati e la selezione della parola giornaliera.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import random
+from typing import Dict, List, Sequence
+
+import streamlit as st
+
+from wordle.daily import get_daily_index, select_daily_word
+from wordle.engine import (
+    MAX_ATTEMPTS,
+    STATUS_GRAY,
+    STATUS_GREEN,
+    STATUS_YELLOW,
+    ValidationError,
+    build_hard_mode_constraints,
+    score_guess,
+    validate_guess,
+)
+from wordle.io_utils import Dictionaries, infer_alphabet, load_dictionaries
+from wordle.keyboard import build_keyboard_rows, should_show_keyboard
+from wordle.render import render_board, render_keyboard, render_share_button, render_toast
+
+st.set_page_config(page_title="Wordle senza limiti", page_icon="🔤", layout="centered")
+
+SYSTEM_RANDOM = random.SystemRandom()
+
+
+def _init_session_state() -> None:
+    st.session_state.setdefault("mode", "daily")
+    st.session_state.setdefault("max_attempts", MAX_ATTEMPTS)
+    st.session_state.setdefault("color_blind", False)
+    st.session_state.setdefault("hard_mode", False)
+    st.session_state.setdefault("stats", {
+        "played": 0,
+        "wins": 0,
+        "current_streak": 0,
+        "max_streak": 0,
+        "distribution": {},
+    })
+    st.session_state.setdefault("guess_input", "")
+    st.session_state.setdefault("game_over", False)
+    st.session_state.setdefault("answer", "")
+    st.session_state.setdefault("answer_signature", "")
+    st.session_state.setdefault("guesses", [])
+    st.session_state.setdefault("evaluations", [])
+    st.session_state.setdefault("result_recorded", False)
+
+
+def _start_new_round(answer: str, *, signature: str) -> None:
+    st.session_state["answer"] = answer
+    st.session_state["answer_signature"] = signature
+    st.session_state["guesses"] = []
+    st.session_state["evaluations"] = []
+    st.session_state["game_over"] = False
+    st.session_state["result_recorded"] = False
+    st.session_state["guess_input"] = ""
+
+
+def _choose_free_word(answers: Sequence[str]) -> str:
+    return SYSTEM_RANDOM.choice(list(answers))
+
+
+def _update_stats(win: bool, attempts_used: int) -> None:
+    stats = st.session_state.get("stats", {})
+    stats.setdefault("distribution", {})
+    stats.setdefault("played", 0)
+    stats.setdefault("wins", 0)
+    stats.setdefault("current_streak", 0)
+    stats.setdefault("max_streak", 0)
+
+    stats["played"] += 1
+    if win:
+        stats["wins"] += 1
+        stats["current_streak"] += 1
+        stats["max_streak"] = max(stats["max_streak"], stats["current_streak"])
+        dist = stats["distribution"]
+        dist[attempts_used] = dist.get(attempts_used, 0) + 1
+    else:
+        stats["current_streak"] = 0
+
+    st.session_state["stats"] = stats
+    st.session_state["result_recorded"] = True
+
+
+def _ensure_answer(dictionaries: Dictionaries, mode: str) -> None:
+    answers = dictionaries.answers
+    if not answers:
+        return
+
+    max_attempts = st.session_state.get("max_attempts", MAX_ATTEMPTS)
+    current_signature = st.session_state.get("answer_signature", "")
+
+    if mode == "daily":
+        index = get_daily_index(answers)
+        signature = f"daily-{index}"
+        if current_signature != signature:
+            answer = select_daily_word(answers)
+            _start_new_round(answer, signature=signature)
+    else:
+        if not current_signature.startswith("free-"):
+            answer = _choose_free_word(answers)
+            signature = f"free-{SYSTEM_RANDOM.randrange(1_000_000_000)}"
+            _start_new_round(answer, signature=signature)
+        elif not st.session_state.get("answer"):
+            answer = _choose_free_word(answers)
+            signature = f"free-{SYSTEM_RANDOM.randrange(1_000_000_000)}"
+            _start_new_round(answer, signature=signature)
+
+    # Adjust board if max attempts decreased below current guesses.
+    guesses = st.session_state.get("guesses", [])
+    evaluations = st.session_state.get("evaluations", [])
+    if len(guesses) > max_attempts:
+        st.session_state["guesses"] = guesses[:max_attempts]
+        st.session_state["evaluations"] = evaluations[:max_attempts]
+
+
+def _build_letter_status(guesses: Sequence[str], evaluations: Sequence[Sequence[str]]) -> Dict[str, str]:
+    priority = {STATUS_GRAY: 0, STATUS_YELLOW: 1, STATUS_GREEN: 2}
+    letter_status: Dict[str, str] = {}
+    for guess, evaluation in zip(guesses, evaluations):
+        for letter, status in zip(guess, evaluation):
+            if not letter.strip():
+                continue
+            normalised = letter.casefold()
+            if normalised not in letter_status or priority[status] > priority[letter_status[normalised]]:
+                letter_status[normalised] = status
+    return letter_status
+
+
+def _show_stats() -> None:
+    stats = st.session_state.get("stats", {})
+    played = stats.get("played", 0)
+    wins = stats.get("wins", 0)
+    win_rate = (wins / played * 100) if played else 0
+    st.sidebar.markdown("### Statistiche")
+    st.sidebar.metric("Partite", played)
+    st.sidebar.metric("Vittorie", wins)
+    st.sidebar.metric("Win rate", f"{win_rate:.0f}%")
+    st.sidebar.metric("Streak", f"{stats.get('current_streak', 0)} / {stats.get('max_streak', 0)}")
+
+    distribution = stats.get("distribution", {})
+    if distribution:
+        st.sidebar.markdown("#### Distribuzione tentativi")
+        for attempt in sorted(distribution):
+            st.sidebar.write(f"{attempt}: {distribution[attempt]}")
+
+
+def main() -> None:
+    _init_session_state()
+
+    dictionaries = load_dictionaries()
+    alphabet = infer_alphabet(dictionaries)
+
+    with st.sidebar:
+        st.markdown("### Impostazioni")
+        max_attempts = st.slider(
+            "Tentativi massimi",
+            min_value=4,
+            max_value=10,
+            value=st.session_state.get("max_attempts", MAX_ATTEMPTS),
+        )
+        st.session_state["max_attempts"] = max_attempts
+        st.session_state["color_blind"] = st.checkbox(
+            "Palette accessibile",
+            value=st.session_state.get("color_blind", False),
+        )
+        st.session_state["hard_mode"] = st.checkbox(
+            "Modalità difficile",
+            value=st.session_state.get("hard_mode", False),
+        )
+        _show_stats()
+
+    st.title("Wordle senza limiti")
+
+    mode_radio = st.radio(
+        "Modalità di gioco",
+        options=("Daily", "Free play"),
+        index=0 if st.session_state.get("mode") == "daily" else 1,
+        horizontal=True,
+    )
+    mode = "daily" if mode_radio == "Daily" else "free"
+    if mode != st.session_state.get("mode"):
+        st.session_state["mode"] = mode
+        st.session_state["answer_signature"] = ""
+        st.session_state["answer"] = ""
+        st.session_state["guesses"] = []
+        st.session_state["evaluations"] = []
+        st.session_state["game_over"] = False
+        st.session_state["result_recorded"] = False
+
+    st.selectbox("Dizionario", options=["Predefinito"], index=0, help="Altri dizionari arriveranno in futuro.")
+
+    if dictionaries.warnings:
+        for warning in dictionaries.warnings:
+            render_toast(warning, level="warning")
+
+    if dictionaries.missing_files:
+        render_toast(
+            "Carica i file in 'data/answers.txt' e 'data/allowed.txt' per iniziare a giocare.",
+            level="error",
+        )
+        return
+
+    if not dictionaries.answers or not dictionaries.allowed:
+        render_toast(
+            "I dizionari devono contenere almeno una parola per poter giocare.",
+            level="error",
+        )
+        return
+
+    _ensure_answer(dictionaries, mode)
+
+    answer = st.session_state.get("answer", "")
+    if not answer:
+        render_toast("Impossibile selezionare una parola. Controlla i dizionari.", level="error")
+        return
+
+    answer_length = len(answer)
+    max_attempts = st.session_state.get("max_attempts", MAX_ATTEMPTS)
+    color_blind = st.session_state.get("color_blind", False)
+    hard_mode = st.session_state.get("hard_mode", False)
+
+    st.caption(f"Parola di {answer_length} lettere")
+    st.caption("Modalità: {}".format("Daily" if mode == "daily" else "Free play"))
+
+    guesses: List[str] = st.session_state.get("guesses", [])
+    evaluations: List[List[str]] = st.session_state.get("evaluations", [])
+
+    render_board(guesses, evaluations, answer_length=answer_length, max_attempts=max_attempts, color_blind=color_blind)
+
+    show_keyboard = should_show_keyboard(alphabet)
+    if show_keyboard:
+        keyboard_rows = build_keyboard_rows(alphabet)
+        letter_status = _build_letter_status(guesses, evaluations)
+        render_keyboard(keyboard_rows, letter_status, color_blind=color_blind)
+
+    if st.session_state.get("game_over") and not st.session_state.get("result_recorded"):
+        win = any(all(status == STATUS_GREEN for status in eval_row) for eval_row in evaluations)
+        _update_stats(win, len(guesses))
+
+    game_over = st.session_state.get("game_over", False)
+
+    with st.form("guess_form", clear_on_submit=False):
+        guess_value = st.text_input(
+            "Inserisci un tentativo",
+            value=st.session_state.get("guess_input", ""),
+            key="guess_input",
+            help="Premi Invio oppure usa i pulsanti sottostanti.",
+            disabled=game_over,
+        )
+        col_submit, col_clear, col_new = st.columns(3)
+        submit = col_submit.form_submit_button("Invia", disabled=game_over)
+        clear = col_clear.form_submit_button("Cancella")
+        new_game = col_new.form_submit_button("Nuova partita")
+
+    if clear:
+        st.session_state["guess_input"] = ""
+        st.experimental_rerun()
+        return
+
+    if new_game:
+        if mode == "daily":
+            signature = st.session_state.get("answer_signature", "")
+            _start_new_round(answer, signature=signature or "daily-reset")
+        else:
+            fresh_answer = _choose_free_word(dictionaries.answers)
+            signature = f"free-{SYSTEM_RANDOM.randrange(1_000_000_000)}"
+            _start_new_round(fresh_answer, signature=signature)
+        st.experimental_rerun()
+        return
+
+    if submit and not game_over:
+        guess = guess_value
+        try:
+            history = list(zip(guesses, evaluations))
+            hard_constraints = None
+            if hard_mode and history:
+                hard_constraints = build_hard_mode_constraints(history)
+            validate_guess(
+                guess,
+                answer,
+                dictionaries.allowed_lookup,
+                hard_constraints=hard_constraints,
+            )
+        except ValidationError as exc:
+            render_toast(str(exc), level="warning")
+        else:
+            normalised = "".join(ch.casefold() for ch in guess)
+            canonical = dictionaries.allowed_lookup.get(normalised, guess)
+            evaluation = score_guess(canonical, answer)
+            guesses.append(canonical)
+            evaluations.append(evaluation)
+            st.session_state["guesses"] = guesses
+            st.session_state["evaluations"] = evaluations
+            st.session_state["guess_input"] = ""
+
+            if all(status == STATUS_GREEN for status in evaluation):
+                st.session_state["game_over"] = True
+                render_toast("Complimenti! Hai indovinato la parola.", level="success")
+            elif len(guesses) >= max_attempts:
+                st.session_state["game_over"] = True
+                render_toast(f"Tentativi esauriti. La parola era '{answer}'.", level="error")
+
+            st.experimental_rerun()
+            return
+
+    attempts_used = len(guesses)
+    render_share_button(guesses, evaluations, attempts_used, max_attempts)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.36
+pytest>=8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is available on PYTHONPATH when running pytest.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta
+
+from zoneinfo import ZoneInfo
+
+from wordle.daily import get_daily_index, select_daily_word
+
+
+ROME = ZoneInfo("Europe/Rome")
+
+
+def test_daily_index_same_day():
+    answers = ["casa", "fiume", "albero"]
+    reference = datetime(2021, 6, 19, 10, tzinfo=ROME)
+    assert get_daily_index(answers, reference) == 0
+    assert select_daily_word(answers, reference) == "casa"
+
+
+def test_daily_index_next_day():
+    answers = ["casa", "fiume", "albero"]
+    reference = datetime(2021, 6, 20, 1, tzinfo=ROME)
+    assert get_daily_index(answers, reference) == 1
+
+
+def test_daily_index_wraps():
+    answers = ["casa", "fiume", "albero"]
+    start = datetime(2021, 6, 19, 8, tzinfo=ROME)
+    future = start + timedelta(days=5)
+    assert get_daily_index(answers, future) == (5 % len(answers))
+

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,0 +1,27 @@
+from wordle.engine import STATUS_GREEN, STATUS_YELLOW, score_guess
+
+
+def test_duplicates_with_accents():
+    guess = "APPÀ"
+    answer = "PAPÀ"
+    assert score_guess(guess, answer) == [
+        STATUS_YELLOW,
+        STATUS_YELLOW,
+        STATUS_GREEN,
+        STATUS_GREEN,
+    ]
+
+
+def test_duplicates_with_repeated_letters():
+    guess = "LLANOBO"
+    answer = "BALLOON"
+    assert score_guess(guess, answer) == [
+        STATUS_YELLOW,
+        STATUS_YELLOW,
+        STATUS_YELLOW,
+        STATUS_YELLOW,
+        STATUS_GREEN,
+        STATUS_YELLOW,
+        STATUS_YELLOW,
+    ]
+

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,60 @@
+import pytest
+
+from wordle.engine import (
+    STATUS_GREEN,
+    STATUS_GRAY,
+    STATUS_YELLOW,
+    ValidationError,
+    build_hard_mode_constraints,
+    score_guess,
+    validate_guess,
+)
+
+
+def test_score_guess_all_green():
+    assert score_guess("casa", "casa") == [STATUS_GREEN] * 4
+
+
+def test_score_guess_mixed_lengths():
+    guess = "gessato"
+    answer = "gestire"
+    assert score_guess(guess, answer) == [
+        STATUS_GREEN,
+        STATUS_GREEN,
+        STATUS_GREEN,
+        STATUS_GRAY,
+        STATUS_GRAY,
+        STATUS_YELLOW,
+        STATUS_GRAY,
+    ]
+
+
+def test_validate_guess_length_mismatch():
+    with pytest.raises(ValidationError):
+        validate_guess("casa", "casale", {"casa": "casa"})
+
+
+def test_validate_guess_unknown_word():
+    allowed_lookup = {"casa": "casa", "fiume": "fiume"}
+    with pytest.raises(ValidationError):
+        validate_guess("lago", "fiume", allowed_lookup)
+
+
+def test_validate_guess_hard_mode_constraints():
+    answer = "cane"
+    first_guess = "casa"
+    evaluation = score_guess(first_guess, answer)
+    history = [(first_guess, evaluation)]
+    constraints = build_hard_mode_constraints(history)
+    allowed_lookup = {
+        "casa": "casa",
+        "cane": "cane",
+        "coro": "coro",
+    }
+
+    with pytest.raises(ValidationError):
+        validate_guess("coro", answer, allowed_lookup, hard_constraints=constraints)
+
+    # Correctly reusing greens succeeds.
+    validate_guess("cane", answer, allowed_lookup, hard_constraints=constraints)
+

--- a/wordle/__init__.py
+++ b/wordle/__init__.py
@@ -1,0 +1,15 @@
+"""Core package for the unlimited-length Wordle clone."""
+
+from .engine import MAX_ATTEMPTS, score_guess, validate_guess
+from .daily import get_daily_index, select_daily_word
+from .io_utils import load_dictionaries, infer_alphabet
+
+__all__ = [
+    "MAX_ATTEMPTS",
+    "score_guess",
+    "validate_guess",
+    "get_daily_index",
+    "select_daily_word",
+    "load_dictionaries",
+    "infer_alphabet",
+]

--- a/wordle/daily.py
+++ b/wordle/daily.py
@@ -1,0 +1,40 @@
+"""Daily word selection logic based on the Europe/Rome timezone."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Sequence
+
+from zoneinfo import ZoneInfo
+
+EUROPE_ROME = ZoneInfo("Europe/Rome")
+BASE_DATE = date(2021, 6, 19)
+
+
+def get_daily_index(answers: Sequence[str], reference: datetime | None = None) -> int:
+    """Return the deterministic index for the daily word.
+
+    The index is derived from the number of days elapsed since BASE_DATE in the
+    Europe/Rome timezone and wraps around when exceeding the answers list.
+    """
+
+    if not answers:
+        raise ValueError("La lista delle risposte è vuota; impossibile selezionare una parola.")
+
+    if reference is None:
+        reference = datetime.now(tz=EUROPE_ROME)
+    else:
+        reference = reference.astimezone(EUROPE_ROME)
+
+    current_date = reference.date()
+    delta_days = (current_date - BASE_DATE).days
+    index = delta_days % len(answers)
+    return index
+
+
+def select_daily_word(answers: Sequence[str], reference: datetime | None = None) -> str:
+    """Return today's word from the provided answers list."""
+
+    index = get_daily_index(answers, reference=reference)
+    return answers[index]
+

--- a/wordle/engine.py
+++ b/wordle/engine.py
@@ -1,0 +1,203 @@
+"""Game engine utilities for the unlimited-length Wordle clone."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+MAX_ATTEMPTS = 6
+
+STATUS_GREEN = "green"
+STATUS_YELLOW = "yellow"
+STATUS_GRAY = "gray"
+STATUS_EMPTY = "empty"
+
+Status = str
+
+
+def _normalise_letter(letter: str) -> str:
+    """Return a normalised representation of a single character."""
+
+    return letter.casefold()
+
+
+@dataclass
+class HardModeConstraints:
+    """Container for the constraints enforced in hard mode.
+
+    Attributes
+    ----------
+    fixed_positions:
+        Mapping position -> normalised letter that must appear in that slot.
+    min_letter_counts:
+        Minimum occurrences required for each normalised letter.
+    disallowed_positions:
+        Mapping position -> set of normalised letters that cannot appear there.
+    letter_display:
+        Mapping normalised letter -> representative character to use in messages.
+    """
+
+    fixed_positions: dict[int, str]
+    min_letter_counts: dict[str, int]
+    disallowed_positions: dict[int, set[str]]
+    letter_display: dict[str, str]
+
+    def display_letter(self, normalised: str) -> str:
+        """Return a user-friendly letter for feedback messages."""
+
+        return self.letter_display.get(normalised, normalised.upper())
+
+
+class ValidationError(ValueError):
+    """Raised when a guess cannot be accepted."""
+
+
+def score_guess(guess: str, answer: str) -> List[Status]:
+    """Score a guess against the answer using Wordle's two-pass algorithm.
+
+    This implementation works with words of arbitrary length and supports any
+    Unicode characters without normalising accents or diacritics.
+    """
+
+    if len(guess) != len(answer):
+        raise ValueError("Guess and answer must have the same length for scoring.")
+
+    answer_letters = list(answer)
+    guess_letters = list(guess)
+
+    answer_norm = [_normalise_letter(ch) for ch in answer_letters]
+    guess_norm = [_normalise_letter(ch) for ch in guess_letters]
+
+    statuses: List[Status] = [STATUS_GRAY] * len(answer_letters)
+    residual_counts: Counter[str] = Counter()
+
+    # First pass: mark greens and gather residual counts from the answer.
+    for idx, (g_norm, a_norm) in enumerate(zip(guess_norm, answer_norm)):
+        if g_norm == a_norm:
+            statuses[idx] = STATUS_GREEN
+        else:
+            residual_counts[a_norm] += 1
+
+    # Second pass: assign yellow where applicable and grey otherwise.
+    for idx, g_norm in enumerate(guess_norm):
+        if statuses[idx] == STATUS_GREEN:
+            continue
+        if residual_counts[g_norm] > 0:
+            statuses[idx] = STATUS_YELLOW
+            residual_counts[g_norm] -= 1
+        else:
+            statuses[idx] = STATUS_GRAY
+
+    return statuses
+
+
+def build_hard_mode_constraints(history: Sequence[Tuple[str, Sequence[Status]]]) -> HardModeConstraints:
+    """Compute hard mode constraints based on the full guess history."""
+
+    fixed_positions: dict[int, str] = {}
+    min_letter_counts: dict[str, int] = {}
+    disallowed_positions: dict[int, set[str]] = defaultdict(set)
+    letter_display: dict[str, str] = {}
+
+    for guess, statuses in history:
+        guess_norm = [_normalise_letter(ch) for ch in guess]
+        per_guess_counts: Counter[str] = Counter()
+        for idx, (letter, norm, status) in enumerate(zip(guess, guess_norm, statuses)):
+            letter_display.setdefault(norm, letter)
+            if status == STATUS_GREEN:
+                fixed_positions[idx] = norm
+                per_guess_counts[norm] += 1
+            elif status == STATUS_YELLOW:
+                disallowed_positions[idx].add(norm)
+                per_guess_counts[norm] += 1
+        for norm, count in per_guess_counts.items():
+            if count > min_letter_counts.get(norm, 0):
+                min_letter_counts[norm] = count
+
+    # Ensure the disallowed sets are plain sets (not defaultdicts) for clarity.
+    disallowed_positions = {idx: set(letters) for idx, letters in disallowed_positions.items()}
+
+    return HardModeConstraints(
+        fixed_positions=fixed_positions,
+        min_letter_counts=min_letter_counts,
+        disallowed_positions=disallowed_positions,
+        letter_display=letter_display,
+    )
+
+
+def validate_guess(
+    guess: str,
+    answer: str,
+    allowed_lookup: dict[str, str],
+    *,
+    hard_constraints: HardModeConstraints | None = None,
+) -> None:
+    """Validate a guess against the active rules.
+
+    Parameters
+    ----------
+    guess:
+        The raw string entered by the user.
+    answer:
+        The current secret word.
+    allowed_lookup:
+        Mapping of normalised words to their canonical representation.
+    hard_constraints:
+        Optional hard mode requirements that must be satisfied.
+
+    Raises
+    ------
+    ValidationError
+        If the guess violates any rule.
+    """
+
+    if not guess:
+        raise ValidationError("Inserisci una parola prima di inviare il tentativo.")
+
+    if guess.strip() != guess:
+        raise ValidationError("Rimuovi spazi iniziali o finali dalla parola inserita.")
+
+    guess_letters = list(guess)
+    guess_norm = [_normalise_letter(ch) for ch in guess_letters]
+
+    if len(guess_norm) != len(answer):
+        raise ValidationError(
+            f"La parola deve contenere esattamente {len(answer)} caratteri."
+        )
+
+    normalised_word = "".join(guess_norm)
+    if normalised_word not in allowed_lookup:
+        raise ValidationError("La parola non è presente nel dizionario consentito.")
+
+    if hard_constraints is None:
+        return
+
+    # Enforce fixed positions (greens).
+    for idx, required_letter in hard_constraints.fixed_positions.items():
+        if guess_norm[idx] != required_letter:
+            display = hard_constraints.display_letter(required_letter)
+            raise ValidationError(
+                f"La modalità difficile richiede la lettera '{display}' nella posizione {idx + 1}."
+            )
+
+    # Enforce minimum counts for discovered letters.
+    guess_counter = Counter(guess_norm)
+    for letter, minimum in hard_constraints.min_letter_counts.items():
+        if guess_counter.get(letter, 0) < minimum:
+            display = hard_constraints.display_letter(letter)
+            raise ValidationError(
+                f"La modalità difficile richiede almeno {minimum} occorrenze della lettera '{display}'."
+            )
+
+    # Enforce that yellow letters are not placed in previously invalid positions.
+    for idx, letters in hard_constraints.disallowed_positions.items():
+        if idx in hard_constraints.fixed_positions:
+            continue
+        if guess_norm[idx] in letters:
+            display = hard_constraints.display_letter(guess_norm[idx])
+            raise ValidationError(
+                "La modalità difficile vieta di ripetere una lettera nota nella stessa posizione."
+            )
+
+

--- a/wordle/io_utils.py
+++ b/wordle/io_utils.py
@@ -1,0 +1,119 @@
+"""Utilities for loading dictionaries and inferring alphabets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Set
+
+DATA_DIR = Path("data")
+ANSWERS_PATH = DATA_DIR / "answers.txt"
+ALLOWED_PATH = DATA_DIR / "allowed.txt"
+
+
+@dataclass
+class Dictionaries:
+    """Container for the words and metadata loaded from disk."""
+
+    answers: List[str]
+    allowed: List[str]
+    allowed_lookup: Dict[str, str]
+    missing_files: List[Path]
+    warnings: List[str]
+
+
+def _ensure_stub(path: Path, sample_words: Iterable[str]) -> bool:
+    """Create a minimal stub file if it does not yet exist."""
+
+    if path.exists():
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = "\n".join(sample_words) + "\n"
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def _normalise_word(word: str) -> str:
+    """Return a canonical representation used for case-insensitive lookups."""
+
+    return word.casefold()
+
+
+def load_dictionaries() -> Dictionaries:
+    """Load dictionary files, creating stubs when missing."""
+
+    missing_files: List[Path] = []
+    warnings: List[str] = []
+
+    stub_created = _ensure_stub(ANSWERS_PATH, ["casa", "fiume", "programmazione"])
+    stub_created |= _ensure_stub(ALLOWED_PATH, ["casa", "fiume", "programmazione", "gioco"])
+
+    if stub_created:
+        warnings.append(
+            "Sono stati creati file di esempio in 'data/'. Sostituiscili con i tuoi dizionari."
+        )
+
+    if not ANSWERS_PATH.exists():
+        missing_files.append(ANSWERS_PATH)
+    if not ALLOWED_PATH.exists():
+        missing_files.append(ALLOWED_PATH)
+
+    answers: List[str] = []
+    allowed: List[str] = []
+    allowed_lookup: Dict[str, str] = {}
+
+    def _load(path: Path, target: List[str], *, is_allowed: bool) -> None:
+        if not path.exists():
+            return
+        raw_text = path.read_text(encoding="utf-8")
+        for line_number, raw_line in enumerate(raw_text.splitlines(), start=1):
+            word = raw_line.strip()
+            if not word:
+                continue
+            if raw_line != word:
+                warnings.append(
+                    f"Riga {line_number} in {path.name} contiene spazi iniziali/finali ed è stata normalizzata."
+                )
+            target.append(word)
+            normalised = _normalise_word(word)
+            if is_allowed and normalised not in allowed_lookup:
+                allowed_lookup[normalised] = word
+
+    _load(ANSWERS_PATH, answers, is_allowed=False)
+    _load(ALLOWED_PATH, allowed, is_allowed=True)
+
+    # Answers should always be accepted as valid guesses.
+    for word in answers:
+        normalised = _normalise_word(word)
+        allowed_lookup.setdefault(normalised, word)
+
+    if not answers:
+        warnings.append(
+            "Il file answers.txt è vuoto. Aggiungi almeno una parola per avviare una partita."
+        )
+    if not allowed:
+        warnings.append(
+            "Il file allowed.txt è vuoto. Nessun tentativo verrà accettato finché non viene popolato."
+        )
+
+    return Dictionaries(
+        answers=answers,
+        allowed=allowed,
+        allowed_lookup=allowed_lookup,
+        missing_files=missing_files,
+        warnings=warnings,
+    )
+
+
+def infer_alphabet(dictionaries: Dictionaries) -> Set[str]:
+    """Infer the alphabet from all available dictionary words."""
+
+    alphabet: Set[str] = set()
+    for word in dictionaries.answers + dictionaries.allowed:
+        for char in word:
+            if char.strip() == "":
+                continue
+            alphabet.add(char)
+    return alphabet
+

--- a/wordle/keyboard.py
+++ b/wordle/keyboard.py
@@ -1,0 +1,60 @@
+"""Helpers to build an optional virtual keyboard."""
+
+from __future__ import annotations
+
+from typing import List, Set
+
+BASIC_QWERTY_ROWS = [
+    "QWERTYUIOP",
+    "ASDFGHJKL",
+    "ZXCVBNM",
+]
+
+
+def should_show_keyboard(alphabet: Set[str]) -> bool:
+    """Return True if the inferred alphabet is small enough for a keyboard."""
+
+    if not alphabet:
+        return False
+    if len(alphabet) > 40:
+        return False
+    return all(len(char) == 1 and char.isprintable() and not char.isspace() for char in alphabet)
+
+
+def build_keyboard_rows(alphabet: Set[str]) -> List[List[str]]:
+    """Organise the alphabet into keyboard rows."""
+
+    if not alphabet:
+        return []
+
+    uppercase_letters = {char.upper() for char in alphabet}
+    english_letters = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+    rows: List[List[str]] = []
+
+    if uppercase_letters <= english_letters:
+        used: Set[str] = set()
+        for pattern in BASIC_QWERTY_ROWS:
+            row = [char for char in pattern if char in uppercase_letters]
+            if row:
+                rows.append(row)
+                used.update(row)
+        remaining = sorted(uppercase_letters - used)
+        if remaining:
+            rows.append(remaining)
+        return rows
+
+    # Generic fallback: sort and chunk into rows of max 10 symbols.
+    sorted_chars = sorted(alphabet, key=lambda c: c.upper())
+    current_row: List[str] = []
+    for char in sorted_chars:
+        display_char = char.upper() if len(char) == 1 else char
+        current_row.append(display_char)
+        if len(current_row) >= 10:
+            rows.append(current_row)
+            current_row = []
+    if current_row:
+        rows.append(current_row)
+
+    return rows
+

--- a/wordle/render.py
+++ b/wordle/render.py
@@ -1,0 +1,258 @@
+"""Rendering helpers for the Streamlit interface."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Sequence
+
+import streamlit as st
+
+from .engine import STATUS_EMPTY, STATUS_GRAY, STATUS_GREEN, STATUS_YELLOW, Status
+
+Palette = Dict[str, str]
+
+
+DEFAULT_PALETTE: Palette = {
+    STATUS_GREEN: "#6aaa64",
+    STATUS_YELLOW: "#c9b458",
+    STATUS_GRAY: "#787c7e",
+    STATUS_EMPTY: "#d3d6da",
+}
+
+COLOR_BLIND_PALETTE: Palette = {
+    STATUS_GREEN: "#f5793a",  # orange
+    STATUS_YELLOW: "#85c0f9",  # blue
+    STATUS_GRAY: "#5f6a72",
+    STATUS_EMPTY: "#c6cbd3",
+}
+
+STATUS_EMOJI = {
+    STATUS_GREEN: "🟩",
+    STATUS_YELLOW: "🟨",
+    STATUS_GRAY: "⬜",
+    STATUS_EMPTY: "⬜",
+}
+
+
+def get_palette(color_blind: bool) -> Palette:
+    """Return the appropriate colour palette."""
+
+    return COLOR_BLIND_PALETTE if color_blind else DEFAULT_PALETTE
+
+
+def inject_base_styles(answer_length: int, *, color_blind: bool) -> None:
+    """Inject CSS required for the board and keyboard."""
+
+    palette = get_palette(color_blind)
+    st.markdown(
+        f"""
+        <style>
+        .wordle-board {{
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+            margin-bottom: 1rem;
+        }}
+        .wordle-row {{
+            display: grid;
+            grid-template-columns: repeat({answer_length}, minmax(2.4rem, 1fr));
+            gap: 0.35rem;
+        }}
+        .wordle-cell {{
+            align-items: center;
+            background-color: {palette[STATUS_EMPTY]};
+            border-radius: 0.35rem;
+            border: 2px solid {palette[STATUS_EMPTY]};
+            color: #1f2933;
+            display: flex;
+            font-size: 1.5rem;
+            font-weight: 700;
+            justify-content: center;
+            min-height: 2.8rem;
+            text-transform: uppercase;
+        }}
+        .wordle-cell.status-green {{
+            background-color: {palette[STATUS_GREEN]};
+            border-color: {palette[STATUS_GREEN]};
+            color: white;
+        }}
+        .wordle-cell.status-yellow {{
+            background-color: {palette[STATUS_YELLOW]};
+            border-color: {palette[STATUS_YELLOW]};
+            color: #1f1f1f;
+        }}
+        .wordle-cell.status-gray {{
+            background-color: {palette[STATUS_GRAY]};
+            border-color: {palette[STATUS_GRAY]};
+            color: white;
+        }}
+        .wordle-keyboard {{
+            display: flex;
+            flex-direction: column;
+            gap: 0.3rem;
+            margin-top: 1.2rem;
+        }}
+        .wordle-keyboard-row {{
+            display: flex;
+            gap: 0.3rem;
+            justify-content: center;
+            flex-wrap: wrap;
+        }}
+        .wordle-key {{
+            background-color: {palette[STATUS_EMPTY]};
+            border-radius: 0.3rem;
+            border: none;
+            color: #111827;
+            font-weight: 600;
+            min-width: 2.2rem;
+            padding: 0.55rem 0.4rem;
+            text-align: center;
+            text-transform: uppercase;
+        }}
+        .wordle-key.status-green {{
+            background-color: {palette[STATUS_GREEN]};
+            color: white;
+        }}
+        .wordle-key.status-yellow {{
+            background-color: {palette[STATUS_YELLOW]};
+            color: #1f1f1f;
+        }}
+        .wordle-key.status-gray {{
+            background-color: {palette[STATUS_GRAY]};
+            color: white;
+        }}
+        @media (max-width: 600px) {{
+            .wordle-row {{
+                grid-template-columns: repeat({answer_length}, minmax(1.9rem, 1fr));
+            }}
+            .wordle-cell {{
+                font-size: 1.2rem;
+                min-height: 2.2rem;
+            }}
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_board(
+    guesses: Sequence[str],
+    evaluations: Sequence[Sequence[Status]],
+    *,
+    answer_length: int,
+    max_attempts: int,
+    color_blind: bool,
+) -> None:
+    """Render the main Wordle board."""
+
+    inject_base_styles(answer_length, color_blind=color_blind)
+
+    padded_guesses: List[str] = list(guesses)[:max_attempts]
+    padded_evaluations: List[Sequence[Status]] = list(evaluations)[:max_attempts]
+
+    while len(padded_guesses) < max_attempts:
+        padded_guesses.append("")
+        padded_evaluations.append([STATUS_EMPTY] * answer_length)
+
+    board_html = ["<div class='wordle-board'>"]
+    for guess, evaluation in zip(padded_guesses, padded_evaluations):
+        row_html = ["<div class='wordle-row'>"]
+        letters = list(guess) + [" "] * max(0, answer_length - len(guess))
+        for letter, status in zip(letters, evaluation):
+            css_class = f"status-{status}"
+            content = letter.upper() if letter.strip() else "&nbsp;"
+            row_html.append(f"<div class='wordle-cell {css_class}'>{content}</div>")
+        row_html.append("</div>")
+        board_html.append("".join(row_html))
+    board_html.append("</div>")
+
+    st.markdown("".join(board_html), unsafe_allow_html=True)
+
+
+def render_keyboard(rows: Sequence[Sequence[str]], letter_status: Dict[str, Status], *, color_blind: bool) -> None:
+    """Render the optional on-screen keyboard."""
+
+    if not rows:
+        return
+
+    mode_class = "color-blind" if color_blind else "default"
+    keyboard_html = [f"<div class='wordle-keyboard {mode_class}'>"]
+    for row in rows:
+        keyboard_html.append("<div class='wordle-keyboard-row'>")
+        for key in row:
+            normalised_key = key.casefold()
+            status = letter_status.get(normalised_key, STATUS_EMPTY)
+            keyboard_html.append(
+                f"<div class='wordle-key status-{status}'>{key}</div>"
+            )
+        keyboard_html.append("</div>")
+    keyboard_html.append("</div>")
+    st.markdown("".join(keyboard_html), unsafe_allow_html=True)
+
+
+def render_toast(message: str, *, level: str = "info") -> None:
+    """Display feedback using the appropriate Streamlit helper."""
+
+    level = level.lower()
+    if level == "success":
+        st.success(message)
+    elif level == "warning":
+        st.warning(message)
+    elif level == "error":
+        st.error(message)
+    else:
+        st.info(message)
+
+
+def render_share_button(
+    guesses: Sequence[str],
+    evaluations: Sequence[Sequence[Status]],
+    attempts_used: int,
+    max_attempts: int,
+) -> None:
+    """Render a button that copies the current game result."""
+
+    if not guesses:
+        st.button("Condividi risultato", disabled=True)
+        return
+
+    emoji_rows = []
+    for evaluation in evaluations:
+        if not evaluation:
+            continue
+        emoji_rows.append("".join(STATUS_EMOJI.get(status, "⬜") for status in evaluation))
+
+    if not emoji_rows:
+        st.button("Condividi risultato", disabled=True)
+        return
+
+    share_text = "Wordle clone — {}/{}".format(attempts_used, max_attempts)
+    share_text += "\n" + "\n".join(emoji_rows)
+
+    if st.button("Condividi risultato"):
+        payload = json.dumps(share_text)
+        st.markdown(
+            f"""
+            <script>
+            const text = {payload};
+            navigator.clipboard.writeText(text).then(() => {{
+                const toast = window.parent.document.createElement('div');
+                toast.innerText = 'Risultato copiato negli appunti!';
+                toast.style.position = 'fixed';
+                toast.style.bottom = '1.5rem';
+                toast.style.left = '50%';
+                toast.style.transform = 'translateX(-50%)';
+                toast.style.background = 'rgba(17,24,39,0.85)';
+                toast.style.color = 'white';
+                toast.style.padding = '0.6rem 1rem';
+                toast.style.borderRadius = '0.4rem';
+                toast.style.zIndex = 9999;
+                window.parent.document.body.appendChild(toast);
+                setTimeout(() => toast.remove(), 2000);
+            }});
+            </script>
+            """,
+            unsafe_allow_html=True,
+        )
+


### PR DESCRIPTION
## Summary
- add modular game engine, dictionary loader, daily selector, rendering and keyboard helpers for unlimited-length words
- build a Streamlit UI with daily/free modes, optional hard mode, virtual keyboard, and shareable results backed by session state
- document usage requirements and provide pytest coverage for scoring, duplicates, and daily selection logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2cf63a6b0832b9c883bc87d0e348b