### PR TITLE
Use flag to clear guess input on new rounds

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ def _start_new_round(answer: str, *, signature: str) -> None:
     st.session_state["evaluations"] = []
     st.session_state["game_over"] = False
     st.session_state["result_recorded"] = False
-    st.session_state["guess_input"] = ""
+    st.session_state["clear_guess_input"] = True
 
 
 def _choose_free_word(answers: Sequence[str]) -> str:


### PR DESCRIPTION
## Summary
* toggle the clear-guess flag when starting a new round so the text input resets through the form handling

## Testing
* pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2dd08fbf8832bafbcf2daa48b3f22