### PR TITLE
Remove allowed word restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ streamlit run app.py
 
 ## Dizionari
 
-La cartella `data/` è inclusa nel repository (vuota a parte da un segnaposto) per ospitare i dizionari personalizzati. La logica si basa su due file di testo posizionati al suo interno:
+La cartella `data/` è inclusa nel repository (vuota a parte da un segnaposto) per ospitare il dizionario delle risposte personalizzato:
 
 - `data/answers.txt`: elenco delle possibili parole segrete, una per riga, senza limitazioni di lunghezza.
-- `data/allowed.txt`: parole accettate come tentativi. Può includere anche le soluzioni.
 
-Se i file non esistono vengono creati automaticamente con un esempio minimo e l'app mostra un avviso. Sostituiscili con i tuoi elenchi (una parola per riga, niente spazi iniziali/finali). Non vengono normalizzati accenti o maiuscole/minuscole: le parole sono confrontate così come scritte nei file.
+Se il file non esiste viene creato automaticamente con un esempio minimo e l'app mostra un avviso. Sostituiscilo con il tuo elenco (una parola per riga, niente spazi iniziali/finali). Non vengono normalizzati accenti o maiuscole/minuscole: le parole sono confrontate così come scritte nel file.
 
 ## Modalità di gioco
 
@@ -34,7 +33,7 @@ Nel pannello laterale puoi modificare il numero massimo di tentativi (default 6)
 
 - Griglia dinamica che si adatta alla lunghezza della parola corrente.
 - Tastiera virtuale mostrata automaticamente quando l'alfabeto dei dizionari è compatto (≤40 simboli stampabili).
-- Campo di input senza limite di caratteri: la validazione assicura che ogni tentativo abbia la stessa lunghezza della soluzione ed esista nel dizionario consentito.
+- Campo di input senza limite di caratteri: la validazione assicura che ogni tentativo abbia la stessa lunghezza della soluzione e rispetti gli eventuali vincoli della modalità difficile.
 - Pulsanti rapidi per inviare, cancellare o avviare una nuova partita e bottone di condivisione che copia negli appunti la griglia in formato emoji.
 
 ## Test

--- a/app.py
+++ b/app.py
@@ -205,14 +205,14 @@ def main() -> None:
 
     if dictionaries.missing_files:
         render_toast(
-            "Carica i file in 'data/answers.txt' e 'data/allowed.txt' per iniziare a giocare.",
+            "Carica il file 'data/answers.txt' per iniziare a giocare.",
             level="error",
         )
         return
 
-    if not dictionaries.answers or not dictionaries.allowed:
+    if not dictionaries.answers:
         render_toast(
-            "I dizionari devono contenere almeno una parola per poter giocare.",
+            "Il dizionario delle risposte deve contenere almeno una parola per poter giocare.",
             level="error",
         )
         return
@@ -291,16 +291,13 @@ def main() -> None:
             validate_guess(
                 guess,
                 answer,
-                dictionaries.allowed_lookup,
                 hard_constraints=hard_constraints,
             )
         except ValidationError as exc:
             render_toast(str(exc), level="warning")
         else:
-            normalised = "".join(ch.casefold() for ch in guess)
-            canonical = dictionaries.allowed_lookup.get(normalised, guess)
-            evaluation = score_guess(canonical, answer)
-            guesses.append(canonical)
+            evaluation = score_guess(guess, answer)
+            guesses.append(guess)
             evaluations.append(evaluation)
             st.session_state["guesses"] = guesses
             st.session_state["evaluations"] = evaluations

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,13 +31,12 @@ def test_score_guess_mixed_lengths():
 
 def test_validate_guess_length_mismatch():
     with pytest.raises(ValidationError):
-        validate_guess("casa", "casale", {"casa": "casa"})
+        validate_guess("casa", "casale")
 
 
-def test_validate_guess_unknown_word():
-    allowed_lookup = {"casa": "casa", "fiume": "fiume"}
-    with pytest.raises(ValidationError):
-        validate_guess("lago", "fiume", allowed_lookup)
+def test_validate_guess_unknown_word_is_allowed():
+    # Any word is accepted provided it satisfies length requirements.
+    validate_guess("laghi", "fiume")
 
 
 def test_validate_guess_hard_mode_constraints():
@@ -46,15 +45,10 @@ def test_validate_guess_hard_mode_constraints():
     evaluation = score_guess(first_guess, answer)
     history = [(first_guess, evaluation)]
     constraints = build_hard_mode_constraints(history)
-    allowed_lookup = {
-        "casa": "casa",
-        "cane": "cane",
-        "coro": "coro",
-    }
 
     with pytest.raises(ValidationError):
-        validate_guess("coro", answer, allowed_lookup, hard_constraints=constraints)
+        validate_guess("coro", answer, hard_constraints=constraints)
 
     # Correctly reusing greens succeeds.
-    validate_guess("cane", answer, allowed_lookup, hard_constraints=constraints)
+    validate_guess("cane", answer, hard_constraints=constraints)
 

--- a/wordle/engine.py
+++ b/wordle/engine.py
@@ -129,20 +129,20 @@ def build_hard_mode_constraints(history: Sequence[Tuple[str, Sequence[Status]]])
 def validate_guess(
     guess: str,
     answer: str,
-    allowed_lookup: dict[str, str],
     *,
     hard_constraints: HardModeConstraints | None = None,
 ) -> None:
     """Validate a guess against the active rules.
 
+    All words are considered valid attempts as long as they satisfy the
+    structural requirements (length, trimming) and any hard mode constraints.
+    
     Parameters
     ----------
     guess:
         The raw string entered by the user.
     answer:
         The current secret word.
-    allowed_lookup:
-        Mapping of normalised words to their canonical representation.
     hard_constraints:
         Optional hard mode requirements that must be satisfied.
 
@@ -165,10 +165,6 @@ def validate_guess(
         raise ValidationError(
             f"La parola deve contenere esattamente {len(answer)} caratteri."
         )
-
-    normalised_word = "".join(guess_norm)
-    if normalised_word not in allowed_lookup:
-        raise ValidationError("La parola non è presente nel dizionario consentito.")
 
     if hard_constraints is None:
         return


### PR DESCRIPTION
## Summary
- drop the allowed guesses dictionary and accept any input word
- simplify validation logic while retaining hard mode constraints
- update the app copy, documentation, and tests to reflect the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d2ae3084832ba96688a92a10120d