### PR TITLE
Validate guesses against answers dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ streamlit run app.py
 
 ## Dizionari
 
-La cartella `data/` è inclusa nel repository (vuota a parte da un segnaposto) per ospitare i dizionari personalizzati. La logica si basa su due file di testo posizionati al suo interno:
+La cartella `data/` è inclusa nel repository (vuota a parte da un segnaposto) per ospitare il dizionario delle risposte personalizzato:
 
-- `data/answers.txt`: elenco delle possibili parole segrete, una per riga, senza limitazioni di lunghezza.
-- `data/allowed.txt`: parole accettate come tentativi. Può includere anche le soluzioni.
+- `data/answers.txt`: elenco delle possibili parole segrete, una per riga, senza limitazioni di lunghezza. I tentativi inseriti nell'app devono appartenere a questo dizionario.
 
-Se i file non esistono vengono creati automaticamente con un esempio minimo e l'app mostra un avviso. Sostituiscili con i tuoi elenchi (una parola per riga, niente spazi iniziali/finali). Non vengono normalizzati accenti o maiuscole/minuscole: le parole sono confrontate così come scritte nei file.
+Se il file non esiste viene creato automaticamente con un esempio minimo e l'app mostra un avviso. Sostituiscilo con il tuo elenco (una parola per riga, niente spazi iniziali/finali). Non vengono normalizzati accenti o maiuscole/minuscole: le parole sono confrontate così come scritte nel file.
 
 ## Modalità di gioco
 
@@ -34,7 +33,7 @@ Nel pannello laterale puoi modificare il numero massimo di tentativi (default 6)
 
 - Griglia dinamica che si adatta alla lunghezza della parola corrente.
 - Tastiera virtuale mostrata automaticamente quando l'alfabeto dei dizionari è compatto (≤40 simboli stampabili).
-- Campo di input senza limite di caratteri: la validazione assicura che ogni tentativo abbia la stessa lunghezza della soluzione ed esista nel dizionario consentito.
+- Campo di input senza limite di caratteri: la validazione assicura che ogni tentativo abbia la stessa lunghezza della soluzione, appartenga al dizionario e rispetti gli eventuali vincoli della modalità difficile.
 - Pulsanti rapidi per inviare, cancellare o avviare una nuova partita e bottone di condivisione che copia negli appunti la griglia in formato emoji.
 
 ## Test

--- a/app.py
+++ b/app.py
@@ -205,14 +205,14 @@ def main() -> None:
 
     if dictionaries.missing_files:
         render_toast(
-            "Carica i file in 'data/answers.txt' e 'data/allowed.txt' per iniziare a giocare.",
+            "Carica il file 'data/answers.txt' per iniziare a giocare.",
             level="error",
         )
         return
 
-    if not dictionaries.answers or not dictionaries.allowed:
+    if not dictionaries.answers:
         render_toast(
-            "I dizionari devono contenere almeno una parola per poter giocare.",
+            "Il dizionario delle risposte deve contenere almeno una parola per poter giocare.",
             level="error",
         )
         return
@@ -291,16 +291,14 @@ def main() -> None:
             validate_guess(
                 guess,
                 answer,
-                dictionaries.allowed_lookup,
+                valid_words=dictionaries.answers_lookup,
                 hard_constraints=hard_constraints,
             )
         except ValidationError as exc:
             render_toast(str(exc), level="warning")
         else:
-            normalised = "".join(ch.casefold() for ch in guess)
-            canonical = dictionaries.allowed_lookup.get(normalised, guess)
-            evaluation = score_guess(canonical, answer)
-            guesses.append(canonical)
+            evaluation = score_guess(guess, answer)
+            guesses.append(guess)
             evaluations.append(evaluation)
             st.session_state["guesses"] = guesses
             st.session_state["evaluations"] = evaluations

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,13 +31,20 @@ def test_score_guess_mixed_lengths():
 
 def test_validate_guess_length_mismatch():
     with pytest.raises(ValidationError):
-        validate_guess("casa", "casale", {"casa": "casa"})
+        validate_guess("casa", "casale")
 
 
-def test_validate_guess_unknown_word():
-    allowed_lookup = {"casa": "casa", "fiume": "fiume"}
+def test_validate_guess_unknown_word_allowed_without_dictionary():
+    validate_guess("laghi", "fiume")
+
+
+def test_validate_guess_unknown_word_rejected_when_dictionary_provided():
     with pytest.raises(ValidationError):
-        validate_guess("lago", "fiume", allowed_lookup)
+        validate_guess("laghi", "fiume", valid_words={"fiume"})
+
+
+def test_validate_guess_dictionary_lookup_is_case_insensitive():
+    validate_guess("FIUME", "fiume", valid_words={"fiume"})
 
 
 def test_validate_guess_hard_mode_constraints():
@@ -46,15 +53,10 @@ def test_validate_guess_hard_mode_constraints():
     evaluation = score_guess(first_guess, answer)
     history = [(first_guess, evaluation)]
     constraints = build_hard_mode_constraints(history)
-    allowed_lookup = {
-        "casa": "casa",
-        "cane": "cane",
-        "coro": "coro",
-    }
 
     with pytest.raises(ValidationError):
-        validate_guess("coro", answer, allowed_lookup, hard_constraints=constraints)
+        validate_guess("coro", answer, hard_constraints=constraints)
 
     # Correctly reusing greens succeeds.
-    validate_guess("cane", answer, allowed_lookup, hard_constraints=constraints)
+    validate_guess("cane", answer, hard_constraints=constraints)
 

--- a/wordle/io_utils.py
+++ b/wordle/io_utils.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Set
+from typing import Iterable, List, Set
 
 DATA_DIR = Path("data")
 ANSWERS_PATH = DATA_DIR / "answers.txt"
-ALLOWED_PATH = DATA_DIR / "allowed.txt"
 
 
 @dataclass
@@ -16,8 +15,7 @@ class Dictionaries:
     """Container for the words and metadata loaded from disk."""
 
     answers: List[str]
-    allowed: List[str]
-    allowed_lookup: Dict[str, str]
+    answers_lookup: Set[str]
     missing_files: List[Path]
     warnings: List[str]
 
@@ -34,12 +32,6 @@ def _ensure_stub(path: Path, sample_words: Iterable[str]) -> bool:
     return True
 
 
-def _normalise_word(word: str) -> str:
-    """Return a canonical representation used for case-insensitive lookups."""
-
-    return word.casefold()
-
-
 def load_dictionaries() -> Dictionaries:
     """Load dictionary files, creating stubs when missing."""
 
@@ -47,7 +39,6 @@ def load_dictionaries() -> Dictionaries:
     warnings: List[str] = []
 
     stub_created = _ensure_stub(ANSWERS_PATH, ["casa", "fiume", "programmazione"])
-    stub_created |= _ensure_stub(ALLOWED_PATH, ["casa", "fiume", "programmazione", "gioco"])
 
     if stub_created:
         warnings.append(
@@ -56,51 +47,31 @@ def load_dictionaries() -> Dictionaries:
 
     if not ANSWERS_PATH.exists():
         missing_files.append(ANSWERS_PATH)
-    if not ALLOWED_PATH.exists():
-        missing_files.append(ALLOWED_PATH)
-
     answers: List[str] = []
-    allowed: List[str] = []
-    allowed_lookup: Dict[str, str] = {}
-
-    def _load(path: Path, target: List[str], *, is_allowed: bool) -> None:
-        if not path.exists():
-            return
-        raw_text = path.read_text(encoding="utf-8")
+    if ANSWERS_PATH.exists():
+        raw_text = ANSWERS_PATH.read_text(encoding="utf-8")
         for line_number, raw_line in enumerate(raw_text.splitlines(), start=1):
             word = raw_line.strip()
             if not word:
                 continue
             if raw_line != word:
                 warnings.append(
-                    f"Riga {line_number} in {path.name} contiene spazi iniziali/finali ed è stata normalizzata."
+                    "Riga {} in answers.txt contiene spazi iniziali/finali ed è stata normalizzata.".format(
+                        line_number
+                    )
                 )
-            target.append(word)
-            normalised = _normalise_word(word)
-            if is_allowed and normalised not in allowed_lookup:
-                allowed_lookup[normalised] = word
+            answers.append(word)
 
-    _load(ANSWERS_PATH, answers, is_allowed=False)
-    _load(ALLOWED_PATH, allowed, is_allowed=True)
-
-    # Answers should always be accepted as valid guesses.
-    for word in answers:
-        normalised = _normalise_word(word)
-        allowed_lookup.setdefault(normalised, word)
+    answers_lookup = {word.casefold() for word in answers}
 
     if not answers:
         warnings.append(
             "Il file answers.txt è vuoto. Aggiungi almeno una parola per avviare una partita."
         )
-    if not allowed:
-        warnings.append(
-            "Il file allowed.txt è vuoto. Nessun tentativo verrà accettato finché non viene popolato."
-        )
 
     return Dictionaries(
         answers=answers,
-        allowed=allowed,
-        allowed_lookup=allowed_lookup,
+        answers_lookup=answers_lookup,
         missing_files=missing_files,
         warnings=warnings,
     )
@@ -110,7 +81,7 @@ def infer_alphabet(dictionaries: Dictionaries) -> Set[str]:
     """Infer the alphabet from all available dictionary words."""
 
     alphabet: Set[str] = set()
-    for word in dictionaries.answers + dictionaries.allowed:
+    for word in dictionaries.answers:
         for char in word:
             if char.strip() == "":
                 continue


### PR DESCRIPTION
## Summary
- validate guesses against the answers dictionary while keeping hard mode checks
- expose the normalised dictionary from load_dictionaries for reuse in the app
- document the dictionary requirement and extend tests for the new validation rules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d2ae3084832ba96688a92a10120d